### PR TITLE
Add support for Eos and Cobalt in a single firmware image

### DIFF
--- a/box_1/box_1_src/box_1_src.ino
+++ b/box_1/box_1_src/box_1_src.ino
@@ -20,47 +20,50 @@
 
 
 /*******************************************************************************
- *
- *   Electronic Theatre Controls
- *
- *   lighthack - Box 1
- *
- *   (c) 2017 by ETC
- *
- *
- *   This code implements a Pan/Tilt module using two encoders and three
- *   buttons. The two encoders function as pan and tilt controllers with one
- *   button being reserved for controlling fine/coarse mode. The other two
- *   buttons are assigned to Next and Last which make it easy to switch between
- *   channels.
- *
+
+     Electronic Theatre Controls
+
+     lighthack - Box 1
+
+     (C) 2017-2018 by ETC
+
+
+     This code implements a Pan/Tilt module using two encoders and three
+     buttons. The two encoders function as pan and tilt controllers with one
+     button being reserved for controlling fine/coarse mode. The other two
+     buttons are assigned to Next and Last which make it easy to switch between
+     channels.
+
  *******************************************************************************
- *
- *  NOTE: UPDATE VERSION_STRING IN DEFINITIONS BELOW WHEN VERSION NUMBER CHANGES
- *
- *  Revision History
- *
- *  yyyy-mm-dd   Vxx      By_Who                 Comment
- *
- *  2017-07-21   1.0.0.1  Ethan Oswald Massey    Original creation
- *
- *  2017-10-19   1.0.0.2  Sam Kearney            Fix build errors on some
- *                                               Arduino platforms. Change
- *                                               OSC subscribe parameters
- *
- *  2017-10-24   1.0.0.3  Sam Kearney            Add ability to scale encoder
- *                                               output
- *
- *  2017-11-22   1.0.0.4  Hans Hinrichsen        Add splash msg before Eos
- *                                               connects
- *
- *  2017-12-07   1.0.0.5  Hans Hinrichsen        Added timeout to disconnect
- *                                               and show splash screen again
- *
+
+    NOTE: UPDATE VERSION_STRING IN DEFINITIONS BELOW WHEN VERSION NUMBER CHANGES
+
+    Revision History
+
+    yyyy-mm-dd   Vxx      By_Who                 Comment
+
+    2017-07-21   1.0.0.1  Ethan Oswald Massey    Original creation
+
+    2017-10-19   1.0.0.2  Sam Kearney            Fix build errors on some
+                                                 Arduino platforms. Change
+                                                 OSC subscribe parameters
+
+    2017-10-24   1.0.0.3  Sam Kearney            Add ability to scale encoder
+                                                 output
+
+    2017-11-22   1.0.0.4  Hans Hinrichsen        Add splash msg before Eos
+                                                 connects
+
+    2017-12-07   1.0.0.5  Hans Hinrichsen        Added timeout to disconnect
+                                                 and show splash screen again
+
+    2018-10-25   2.0.0.0  Richard Thompson       Generalised to support other
+                                                 ETC consoles
+
  ******************************************************************************/
 
 /*******************************************************************************
- * Includes
+   Includes
  ******************************************************************************/
 #include <OSCBoards.h>
 #include <OSCBundle.h>
@@ -78,9 +81,9 @@ SLIPEncodedSerial SLIPSerial(Serial);
 #include <LiquidCrystal.h>
 #include <string.h>
 
- /*******************************************************************************
-  * Macros and Constants
-  ******************************************************************************/
+/*******************************************************************************
+   Macros and Constants
+ ******************************************************************************/
 #define LCD_CHARS           16
 #define LCD_LINES           2   // Currently assume at least 2 lines
 
@@ -101,9 +104,10 @@ SLIPEncodedSerial SLIPSerial(Serial);
 #define PAN_DIR             FORWARD
 #define TILT_DIR            FORWARD
 
-// Use these values to make the encoder more coarse or fine. This controls
-// the number of wheel "ticks" the device sends to Eos for each tick of the
-// encoder. 1 is the default and the most fine setting. Must be an integer.
+// Use these values to make the encoder more coarse or fine.
+// This controls the number of wheel "ticks" the device sends to the console
+// for each tick of the encoder. 1 is the default and the most fine setting.
+// Must be an integer.
 #define PAN_SCALE           1
 #define TILT_SCALE          1
 
@@ -115,7 +119,9 @@ const String HANDSHAKE_QUERY = "ETCOSC?";
 const String HANDSHAKE_REPLY = "OK";
 
 //See displayScreen() below - limited to 10 chars (after 6 prefix chars)
-const String VERSION_STRING = "1.0.0.5";
+#define VERSION_STRING      "2.0.0.0"
+
+#define BOX_NAME_STRING     "box1"
 
 // Change these values to alter how long we wait before sending an OSC ping
 // to see if Eos is still there, and then finally how long before we
@@ -125,468 +131,556 @@ const String VERSION_STRING = "1.0.0.5";
 #define TIMEOUT_AFTER_IDLE_INTERVAL 5000
 
 /*******************************************************************************
- * Local Types
+   Local Types
  ******************************************************************************/
 enum WHEEL_TYPE { TILT, PAN };
 enum WHEEL_MODE { COARSE, FINE };
 
 struct Encoder
 {
-    uint8_t pinA;
-    uint8_t pinB;
-    int pinAPrevious;
-    int pinBPrevious;
-    float pos;
-    uint8_t direction;
+  uint8_t pinA;
+  uint8_t pinB;
+  int pinAPrevious;
+  int pinBPrevious;
+  float pos;
+  uint8_t direction;
 };
 struct Encoder panWheel;
 struct Encoder tiltWheel;
 
+enum ConsoleType
+{
+  ConsoleNone,
+  ConsoleEos,
+  ConsoleCobalt,
+};
+
 /*******************************************************************************
- * Global Variables
+   Global Variables
  ******************************************************************************/
 
 // initialize the library with the numbers of the interface pins
 LiquidCrystal lcd(12, 11, 5, 4, 3, 2);
 
 bool updateDisplay = false;
-bool connectedToEos = false;
+ConsoleType connectedToConsole = ConsoleNone;
 unsigned long lastMessageRxTime = 0;
 bool timeoutPingSent = false;
 
 /*******************************************************************************
- * Local Functions
+   Local Functions
  ******************************************************************************/
 
 /*******************************************************************************
- * Issues all our subscribes to Eos. When subscribed, Eos will keep us updated
- * with the latest values for a given parameter.
- *
- * Parameters:  none
- *
- * Return Value: void
- *
+   Issues all our subscribes to Eos. When subscribed, Eos will keep us updated
+   with the latest values for a given parameter.
+
+   Parameters:  none
+
+   Return Value: void
+
  ******************************************************************************/
-void issueSubscribes()
+void issueEosSubscribes()
 {
-    // Add a filter so we don't get spammed with unwanted OSC messages from Eos
-    OSCMessage filter("/eos/filter/add");
-    filter.add("/eos/out/param/*");
-    filter.add("/eos/out/ping");
-    SLIPSerial.beginPacket();
-    filter.send(SLIPSerial);
-    SLIPSerial.endPacket();
+  // Add a filter so we don't get spammed with unwanted OSC messages from Eos
+  OSCMessage filter("/eos/filter/add");
+  filter.add("/eos/out/param/*");
+  filter.add("/eos/out/ping");
+  SLIPSerial.beginPacket();
+  filter.send(SLIPSerial);
+  SLIPSerial.endPacket();
 
-    // subscribe to Eos pan & tilt updates
-    OSCMessage subPan("/eos/subscribe/param/pan");
-    subPan.add(SUBSCRIBE);
-    SLIPSerial.beginPacket();
-    subPan.send(SLIPSerial);
-    SLIPSerial.endPacket();
+  // subscribe to Eos pan & tilt updates
+  OSCMessage subPan("/eos/subscribe/param/pan");
+  subPan.add(SUBSCRIBE);
+  SLIPSerial.beginPacket();
+  subPan.send(SLIPSerial);
+  SLIPSerial.endPacket();
 
-    OSCMessage subTilt("/eos/subscribe/param/tilt");
-    subTilt.add(SUBSCRIBE);
-    SLIPSerial.beginPacket();
-    subTilt.send(SLIPSerial);
-    SLIPSerial.endPacket();
+  OSCMessage subTilt("/eos/subscribe/param/tilt");
+  subTilt.add(SUBSCRIBE);
+  SLIPSerial.beginPacket();
+  subTilt.send(SLIPSerial);
+  SLIPSerial.endPacket();
 }
 
 /*******************************************************************************
- * Given a valid OSCMessage (relevant to Pan/Tilt), we update our Encoder struct
- * with the new position information.
- *
- * Parameters:
- *  msg - The OSC message we will use to update our internal data
- *  addressOffset - Unused (allows for multiple nested roots)
- *
- * Return Value: void
- *
+   Given a valid OSCMessage (relevant to Pan/Tilt), we update our Encoder struct
+   with the new position information.
+
+   Parameters:
+    msg - The OSC message we will use to update our internal data
+    addressOffset - Unused (allows for multiple nested roots)
+
+   Return Value: void
+
  ******************************************************************************/
-void parsePanUpdate(OSCMessage& msg, int addressOffset)
+void parseFloatPanUpdate(OSCMessage& msg, int addressOffset)
 {
-    panWheel.pos = msg.getOSCData(0)->getFloat();
-    connectedToEos = true; // Update this here just in case we missed the handshake
+  panWheel.pos = msg.getOSCData(0)->getFloat();
+  updateDisplay = true;
+}
+
+void parseFloatTiltUpdate(OSCMessage& msg, int addressOffset)
+{
+  tiltWheel.pos = msg.getOSCData(0)->getFloat();
+  updateDisplay = true;
+}
+
+void parseEos(OSCMessage& msg, int addressOffset)
+{
+  // If we don't think we're connected, reconnect and subscribe
+  if (connectedToConsole != ConsoleEos)
+  {
+    issueEosSubscribes();
+    connectedToConsole = ConsoleEos;
     updateDisplay = true;
+  }
+
+  if (!msg.route("/out/param/pan", parseFloatPanUpdate, addressOffset))
+    msg.route("/out/param/tilt", parseFloatTiltUpdate, addressOffset);
 }
 
-void parseTiltUpdate(OSCMessage& msg, int addressOffset)
+/******************************************************************************/
+
+void parseCobalt(OSCMessage& msg, int addressOffset)
 {
-    tiltWheel.pos = msg.getOSCData(0)->getFloat();
-    connectedToEos = true; // Update this here just in case we missed the handshake
-    updateDisplay = true;
+  // Cobalt doesn't currently send anything other than ping
+  connectedToConsole = ConsoleCobalt;
+  updateDisplay = true;
 }
 
 /*******************************************************************************
- * Given an unknown OSC message we check to see if it's a handshake message.
- * If it's a handshake we issue a subscribe, otherwise we begin route the OSC
- * message to the appropriate function.
- *
- * Parameters:
- *  msg - The OSC message of unknown importance
- *
- * Return Value: void
- *
+   Given an unknown OSC message we check to see if it's a handshake message.
+   If it's a handshake we issue a subscribe, otherwise we begin route the OSC
+   message to the appropriate function.
+
+   Parameters:
+    msg - The OSC message of unknown importance
+
+   Return Value: void
+
  ******************************************************************************/
 void parseOSCMessage(String& msg)
 {
-    // check to see if this is the handshake string
-    if (msg.indexOf(HANDSHAKE_QUERY) != -1)
-    {
-        // handshake string found!
-        SLIPSerial.beginPacket();
-        SLIPSerial.write((const uint8_t*)HANDSHAKE_REPLY.c_str(), (size_t)HANDSHAKE_REPLY.length());
-        SLIPSerial.endPacket();
-
-        // Let Eos know we want updates on some things
-        issueSubscribes();
-
-        // Make our splash screen go away
-        connectedToEos = true;
-        updateDisplay = true;
-    }
-    else
-    {
-        // prepare the message for routing by filling an OSCMessage object with our message string
-        OSCMessage oscmsg;
-        oscmsg.fill((uint8_t*)msg.c_str(), (int)msg.length());
-        // route pan/tilt messages to the relevant update function
-        oscmsg.route("/eos/out/param/pan", parsePanUpdate);
-        oscmsg.route("/eos/out/param/tilt", parseTiltUpdate);
-    }
-}
-
-/*******************************************************************************
- * Updates the display with the latest pan and tilt positions.
- *
- * Parameters:  none
- *
- * Return Value: void
- *
- ******************************************************************************/
-void displayStatus()
-{
-    lcd.clear();
-
-    if (!connectedToEos)
-    {
-      // display a splash message before the Eos connection is open
-      lcd.setCursor(0, 0);
-      lcd.print(String("Box1 v" + VERSION_STRING).c_str());
-      lcd.setCursor(0, 1);
-      lcd.print("waiting for eos");
-    }
-    else
-    {
-      // put the cursor at the begining of the first line
-      lcd.setCursor(0, 0);
-      lcd.print("Pan:  ");
-      lcd.print(panWheel.pos, SIG_DIGITS);
-
-      // put the cursor at the begining of the second line
-      lcd.setCursor(0, 1);
-      lcd.print("Tilt: ");
-      lcd.print(tiltWheel.pos, SIG_DIGITS);
-    }
-
-    updateDisplay = false;
-}
-
-/*******************************************************************************
- * Initializes a given encoder struct to the requested parameters.
- *
- * Parameters:
- *  encoder - Pointer to the encoder we will be initializing
- *  pinA - Where the A pin is connected to the Arduino
- *  pinB - Where the B pin is connected to the Arduino
- *  direction - Determines if clockwise or counterclockwise is "forward"
- *
- * Return Value: void
- *
- ******************************************************************************/
-void initEncoder(struct Encoder* encoder, uint8_t pinA, uint8_t pinB, uint8_t direction)
-{
-    encoder->pinA = pinA;
-    encoder->pinB = pinB;
-    encoder->pos = 0;
-    encoder->direction = direction;
-
-    pinMode(pinA, INPUT_PULLUP);
-    pinMode(pinB, INPUT_PULLUP);
-
-    encoder->pinAPrevious = digitalRead(pinA);
-    encoder->pinBPrevious = digitalRead(pinB);
-}
-
-/*******************************************************************************
- * Checks if the encoder has moved by comparing the previous state of the pins
- * with the current state. If they are different, we know there is movement.
- * In the event of movement we update the current state of our pins.
- *
- * Parameters:
- *  encoder - Pointer to the encoder we will be checking for motion
- *
- * Return Value:
- *  encoderMotion - Returns the 0 if the encoder has not moved
- *                              1 for forward motion
- *                             -1 for reverse motion
- *
- ******************************************************************************/
-int8_t updateEncoder(struct Encoder* encoder)
-{
-    int8_t encoderMotion = 0;
-    int pinACurrent = digitalRead(encoder->pinA);
-    int pinBCurrent = digitalRead(encoder->pinB);
-
-    // has the encoder moved at all?
-    if (encoder->pinAPrevious != pinACurrent)
-    {
-        // Since it has moved, we must determine if the encoder has moved forwards or backwards
-        encoderMotion = (encoder->pinAPrevious == encoder->pinBPrevious) ? -1 : 1;
-
-        // If we are in reverse mode, flip the direction of the encoder motion
-        if (encoder->direction == REVERSE)
-            encoderMotion = -encoderMotion;
-    }
-    encoder->pinAPrevious = pinACurrent;
-    encoder->pinBPrevious = pinBCurrent;
-
-    return encoderMotion;
-}
-
-/*******************************************************************************
- * Sends a message to Eos informing them of a wheel movement.
- *
- * Parameters:
- *  type - the type of wheel that's moving (i.e. pan or tilt)
- *  ticks - the direction and intensity of the movement
- *
- * Return Value: void
- *
- ******************************************************************************/
-void sendWheelMove(WHEEL_TYPE type, float ticks)
-{
-    String wheelMsg("/eos/wheel");
-
-    if (digitalRead(SHIFT_BTN) == LOW)
-        wheelMsg.concat("/fine");
-    else
-        wheelMsg.concat("/coarse");
-
-    if (type == PAN)
-        wheelMsg.concat("/pan");
-    else if (type == TILT)
-        wheelMsg.concat("/tilt");
-    else
-        // something has gone very wrong
-        return;
-
-    OSCMessage wheelUpdate(wheelMsg.c_str());
-    wheelUpdate.add(ticks);
-    SLIPSerial.beginPacket();
-    wheelUpdate.send(SLIPSerial);
-    SLIPSerial.endPacket();
-}
-
-/*******************************************************************************
- * Sends a message to Eos informing them of a key press.
- *
- * Parameters:
- *  down - whether a key has been pushed down (true) or released (false)
- *  key - the key that has moved
- *
- * Return Value: void
- *
- ******************************************************************************/
-void sendKeyPress(bool down, String key)
-{
-    key = "/eos/key/" + key;
-    OSCMessage keyMsg(key.c_str());
-
-    if (down)
-        keyMsg.add(EDGE_DOWN);
-    else
-        keyMsg.add(EDGE_UP);
-
-    SLIPSerial.beginPacket();
-    keyMsg.send(SLIPSerial);
-    SLIPSerial.endPacket();
-}
-
-/*******************************************************************************
- * Checks the status of all the buttons relevant to Eos (i.e. Next & Last)
- *
- * NOTE: This does not check the shift key. The shift key is used in tandem with
- * the encoder to determine coarse/fine mode and thus does not report to Eos
- * directly.
- *
- * Parameters: none
- *
- * Return Value: void
- *
- ******************************************************************************/
-void checkButtons()
-{
-    static int nextKeyState = HIGH;
-    static int lastKeyState = HIGH;
-
-    // Has the button state changed
-    if (digitalRead(NEXT_BTN) != nextKeyState)
-    {
-        // Notify Eos of this key press
-        if (nextKeyState == LOW)
-        {
-            sendKeyPress(false, "NEXT");
-            nextKeyState = HIGH;
-        }
-        else
-        {
-            sendKeyPress(true, "NEXT");
-            nextKeyState = LOW;
-        }
-    }
-
-    if (digitalRead(LAST_BTN) != lastKeyState)
-    {
-        if (lastKeyState == LOW)
-        {
-            sendKeyPress(false, "LAST");
-            lastKeyState = HIGH;
-        }
-        else
-        {
-            sendKeyPress(true, "LAST");
-            lastKeyState = LOW;
-        }
-    }
-}
-
-/*******************************************************************************
- * Here we setup our encoder, lcd, and various input devices. We also prepare
- * to communicate OSC with Eos by setting up SLIPSerial. Once we are done with
- * setup() we pass control over to loop() and never call setup() again.
- *
- * NOTE: This function is the entry function. This is where control over the
- * Arduino is passed to us (the end user).
- *
- * Parameters: none
- *
- * Return Value: void
- *
- ******************************************************************************/
-void setup()
-{
-    SLIPSerial.begin(115200);
-    // This is a hack around an Arduino bug. It was taken from the OSC library
-    //examples
-#ifdef BOARD_HAS_USB_SERIAL
-    while (!SerialUSB);
-#else
-    while (!Serial);
-#endif
-
-    // This is necessary for reconnecting a device because it needs some time
-    // for the serial port to open, but meanwhile the handshake message was
-    // sent from Eos
+  // check to see if this is the handshake string
+  if (msg.indexOf(HANDSHAKE_QUERY) != -1)
+  {
+    // handshake string found!
     SLIPSerial.beginPacket();
     SLIPSerial.write((const uint8_t*)HANDSHAKE_REPLY.c_str(), (size_t)HANDSHAKE_REPLY.length());
     SLIPSerial.endPacket();
+
+    // An Eos would do nothing until subscribed
     // Let Eos know we want updates on some things
-    issueSubscribes();
+    issueEosSubscribes();
+    
+    updateDisplay = true;
+  }
+  else
+  {
+    // prepare the message for routing by filling an OSCMessage object with our message string
+    OSCMessage oscmsg;
+    oscmsg.fill((uint8_t*)msg.c_str(), (int)msg.length());
+    // route pan/tilt messages to the relevant update function
 
-    initEncoder(&panWheel, A0, A1, PAN_DIR);
-    initEncoder(&tiltWheel, A3, A4, TILT_DIR);
-
-    lcd.begin(LCD_CHARS, LCD_LINES);
-    lcd.clear();
-
-    pinMode(NEXT_BTN, INPUT_PULLUP);
-    pinMode(LAST_BTN, INPUT_PULLUP);
-    pinMode(SHIFT_BTN, INPUT_PULLUP);
-
-    displayStatus();
+    // Try the various OSC routes
+    if (!oscmsg.route("/eos", parseEos))
+      oscmsg.route("/cobalt", parseCobalt);
+  }
 }
 
 /*******************************************************************************
- * Here we service, monitor, and otherwise control all our peripheral devices.
- * First, we retrieve the status of our encoders and buttons and update Eos.
- * Next, we check if there are any OSC messages for us.
- * Finally, we update our display (if an update is necessary)
- *
- * NOTE: This function is our main loop and thus this function will be called
- * repeatedly forever
- *
- * Parameters: none
- *
- * Return Value: void
- *
+   Updates the display with the latest pan and tilt positions.
+
+   Parameters:  none
+
+   Return Value: void
+
+ ******************************************************************************/
+void displayStatus()
+{
+  lcd.clear();
+
+  switch (connectedToConsole)
+  {
+    case ConsoleNone:
+      {
+        // display a splash message before the Eos connection is open
+        lcd.setCursor(0, 0);
+        lcd.print(BOX_NAME_STRING " v" VERSION_STRING);
+        lcd.setCursor(0, 1);
+        lcd.print("Waiting...");
+      } break;
+
+    case ConsoleEos:
+      {
+        // put the cursor at the begining of the first line
+        lcd.setCursor(0, 0);
+        lcd.print("Pan:  ");
+        lcd.print(panWheel.pos, SIG_DIGITS);
+
+        // put the cursor at the begining of the second line
+        lcd.setCursor(0, 1);
+        lcd.print("Tilt: ");
+        lcd.print(tiltWheel.pos, SIG_DIGITS);
+      } break;
+
+    case ConsoleCobalt:
+      {
+        lcd.setCursor(0, 0);
+        lcd.print("Cobalt");
+      }
+  }
+
+  updateDisplay = false;
+}
+
+/*******************************************************************************
+   Initializes a given encoder struct to the requested parameters.
+
+   Parameters:
+    encoder - Pointer to the encoder we will be initializing
+    pinA - Where the A pin is connected to the Arduino
+    pinB - Where the B pin is connected to the Arduino
+    direction - Determines if clockwise or counterclockwise is "forward"
+
+   Return Value: void
+
+ ******************************************************************************/
+void initEncoder(struct Encoder* encoder, uint8_t pinA, uint8_t pinB, uint8_t direction)
+{
+  encoder->pinA = pinA;
+  encoder->pinB = pinB;
+  encoder->pos = 0;
+  encoder->direction = direction;
+
+  pinMode(pinA, INPUT_PULLUP);
+  pinMode(pinB, INPUT_PULLUP);
+
+  encoder->pinAPrevious = digitalRead(pinA);
+  encoder->pinBPrevious = digitalRead(pinB);
+}
+
+/*******************************************************************************
+   Checks if the encoder has moved by comparing the previous state of the pins
+   with the current state. If they are different, we know there is movement.
+   In the event of movement we update the current state of our pins.
+
+   Parameters:
+    encoder - Pointer to the encoder we will be checking for motion
+
+   Return Value:
+    encoderMotion - Returns the 0 if the encoder has not moved
+                                1 for forward motion
+                               -1 for reverse motion
+
+ ******************************************************************************/
+int8_t updateEncoder(struct Encoder* encoder)
+{
+  int8_t encoderMotion = 0;
+  int pinACurrent = digitalRead(encoder->pinA);
+  int pinBCurrent = digitalRead(encoder->pinB);
+
+  // has the encoder moved at all?
+  if (encoder->pinAPrevious != pinACurrent)
+  {
+    // Since it has moved, we must determine if the encoder has moved forwards or backwards
+    encoderMotion = (encoder->pinAPrevious == encoder->pinBPrevious) ? -1 : 1;
+
+    // If we are in reverse mode, flip the direction of the encoder motion
+    if (encoder->direction == REVERSE)
+      encoderMotion = -encoderMotion;
+  }
+  encoder->pinAPrevious = pinACurrent;
+  encoder->pinBPrevious = pinBCurrent;
+
+  return encoderMotion;
+}
+
+/*******************************************************************************
+   Sends a message to Eos informing them of a wheel movement.
+
+   Parameters:
+    type - the type of wheel that's moving (i.e. pan or tilt)
+    ticks - the direction and intensity of the movement
+
+   Return Value: void
+
+ ******************************************************************************/
+void sendEosWheelMove(WHEEL_TYPE type, float ticks)
+{
+  String wheelMsg("/eos/wheel");
+
+  if (digitalRead(SHIFT_BTN) == LOW)
+    wheelMsg.concat("/fine");
+  else
+    wheelMsg.concat("/coarse");
+
+  if (type == PAN)
+    wheelMsg.concat("/pan");
+  else if (type == TILT)
+    wheelMsg.concat("/tilt");
+  else
+    // something has gone very wrong
+    return;
+
+  OSCMessage wheelUpdate(wheelMsg.c_str());
+  wheelUpdate.add(ticks);
+  SLIPSerial.beginPacket();
+  wheelUpdate.send(SLIPSerial);
+  SLIPSerial.endPacket();
+}
+
+void sendCobaltWheelMove(WHEEL_TYPE type, float ticks)
+{
+  String wheelMsg("/cobalt/param");
+
+  if (type == PAN)
+    wheelMsg.concat("/pan/wheel");
+  else if (type == TILT)
+    wheelMsg.concat("/tilt/wheel");
+  else
+    // something has gone very wrong
+    return;
+
+  if (digitalRead(SHIFT_BTN) != LOW)
+    ticks = ticks * 16;
+
+  OSCMessage wheelUpdate(wheelMsg.c_str());
+  wheelUpdate.add(ticks);
+  SLIPSerial.beginPacket();
+  wheelUpdate.send(SLIPSerial);
+  SLIPSerial.endPacket();
+}
+
+/******************************************************************************/
+
+void sendWheelMove(WHEEL_TYPE type, float ticks)
+{
+  switch (connectedToConsole)
+  {
+    default:
+    case ConsoleEos:
+      sendEosWheelMove(type, ticks);
+      break;
+    case ConsoleCobalt:
+      sendCobaltWheelMove(type, ticks);
+      break;
+  }
+}
+
+/*******************************************************************************
+   Sends a message to Eos informing them of a key press.
+
+   Parameters:
+    down - whether a key has been pushed down (true) or released (false)
+    key - the key that has moved
+
+   Return Value: void
+
+ ******************************************************************************/
+void sendKeyPress(bool down, String key)
+{
+  String keyAddress;
+  switch (connectedToConsole)
+  {
+    default:
+    case ConsoleEos:
+      keyAddress = "/eos/key/" + key;
+      break;
+    case ConsoleCobalt:
+      keyAddress = "/cobalt/key/" + key;
+      break;
+  }
+  OSCMessage keyMsg(keyAddress.c_str());
+
+  if (down)
+    keyMsg.add(EDGE_DOWN);
+  else
+    keyMsg.add(EDGE_UP);
+
+  SLIPSerial.beginPacket();
+  keyMsg.send(SLIPSerial);
+  SLIPSerial.endPacket();
+}
+
+/*******************************************************************************
+   Checks the status of all the buttons relevant to Eos (i.e. Next & Last)
+
+   NOTE: This does not check the shift key. The shift key is used in tandem with
+   the encoder to determine coarse/fine mode and thus does not report to Eos
+   directly.
+
+   Parameters: none
+
+   Return Value: void
+
+ ******************************************************************************/
+void checkButtons()
+{
+  static int nextKeyState = HIGH;
+  static int lastKeyState = HIGH;
+
+  // Has the button state changed
+  if (digitalRead(NEXT_BTN) != nextKeyState)
+  {
+    // Notify Eos of this key press
+    if (nextKeyState == LOW)
+    {
+      sendKeyPress(false, "NEXT");
+      nextKeyState = HIGH;
+    }
+    else
+    {
+      sendKeyPress(true, "NEXT");
+      nextKeyState = LOW;
+    }
+  }
+
+  if (digitalRead(LAST_BTN) != lastKeyState)
+  {
+    if (lastKeyState == LOW)
+    {
+      sendKeyPress(false, "LAST");
+      lastKeyState = HIGH;
+    }
+    else
+    {
+      sendKeyPress(true, "LAST");
+      lastKeyState = LOW;
+    }
+  }
+}
+
+/*******************************************************************************
+   Here we setup our encoder, lcd, and various input devices. We also prepare
+   to communicate OSC with Eos by setting up SLIPSerial. Once we are done with
+   setup() we pass control over to loop() and never call setup() again.
+
+   NOTE: This function is the entry function. This is where control over the
+   Arduino is passed to us (the end user).
+
+   Parameters: none
+
+   Return Value: void
+
+ ******************************************************************************/
+void setup()
+{
+  SLIPSerial.begin(115200);
+  // This is a hack around an Arduino bug. It was taken from the OSC library
+  //examples
+#ifdef BOARD_HAS_USB_SERIAL
+  while (!SerialUSB);
+#else
+  while (!Serial);
+#endif
+
+  // This is necessary for reconnecting a device because it needs some time
+  // for the serial port to open. The handshake message may have been sent
+  // from the console before #lighthack was ready
+
+  SLIPSerial.beginPacket();
+  SLIPSerial.write((const uint8_t*)HANDSHAKE_REPLY.c_str(), (size_t)HANDSHAKE_REPLY.length());
+  SLIPSerial.endPacket();
+
+  // If it's an Eos, request updates on some things
+  issueEosSubscribes();
+
+  initEncoder(&panWheel, A0, A1, PAN_DIR);
+  initEncoder(&tiltWheel, A3, A4, TILT_DIR);
+
+  lcd.begin(LCD_CHARS, LCD_LINES);
+  lcd.clear();
+
+  pinMode(NEXT_BTN, INPUT_PULLUP);
+  pinMode(LAST_BTN, INPUT_PULLUP);
+  pinMode(SHIFT_BTN, INPUT_PULLUP);
+
+  displayStatus();
+}
+
+/*******************************************************************************
+   Here we service, monitor, and otherwise control all our peripheral devices.
+   First, we retrieve the status of our encoders and buttons and update Eos.
+   Next, we check if there are any OSC messages for us.
+   Finally, we update our display (if an update is necessary)
+
+   NOTE: This function is our main loop and thus this function will be called
+   repeatedly forever
+
+   Parameters: none
+
+   Return Value: void
+
  ******************************************************************************/
 void loop()
 {
-    static String curMsg;
-    int size;
-    // get the updated state of each encoder
-    int32_t panMotion = updateEncoder(&panWheel);
-    int32_t tiltMotion = updateEncoder(&tiltWheel);
+  static String curMsg;
+  int size;
+  // get the updated state of each encoder
+  int32_t panMotion = updateEncoder(&panWheel);
+  int32_t tiltMotion = updateEncoder(&tiltWheel);
 
-    // Scale the result by a scaling factor
-    panMotion *= PAN_SCALE;
-    tiltMotion *= TILT_SCALE;
+  // Scale the result by a scaling factor
+  panMotion *= PAN_SCALE;
+  tiltMotion *= TILT_SCALE;
 
-    // check for next/last updates
-    checkButtons();
+  // check for next/last updates
+  checkButtons();
 
-    // now update our wheels
-    if (tiltMotion != 0)
-        sendWheelMove(TILT, tiltMotion);
+  // now update our wheels
+  if (tiltMotion != 0)
+    sendWheelMove(TILT, tiltMotion);
 
-    if (panMotion != 0)
-        sendWheelMove(PAN, panMotion);
+  if (panMotion != 0)
+    sendWheelMove(PAN, panMotion);
 
-    // Then we check to see if any OSC commands have come from Eos
-    // and update the display accordingly.
-    size = SLIPSerial.available();
-    if (size > 0)
+  // Then we check to see if any OSC commands have come from Eos
+  // and update the display accordingly.
+  size = SLIPSerial.available();
+  if (size > 0)
+  {
+    // Fill the msg with all of the available bytes
+    while (size--)
+      curMsg += (char)(SLIPSerial.read());
+  }
+  if (SLIPSerial.endofPacket())
+  {
+    parseOSCMessage(curMsg);
+    lastMessageRxTime = millis();
+    // We only care about the ping if we haven't heard recently
+    // Clear flag when we get any traffic
+    timeoutPingSent = false;
+    curMsg = String();
+  }
+
+  if (lastMessageRxTime > 0)
+  {
+    unsigned long diff = millis() - lastMessageRxTime;
+    //We first check if it's been too long and we need to time out
+    if (diff > TIMEOUT_AFTER_IDLE_INTERVAL)
     {
-        // Fill the msg with all of the available bytes
-        while (size--)
-            curMsg += (char)(SLIPSerial.read());
-    }
-    if (SLIPSerial.endofPacket())
-    {
-        parseOSCMessage(curMsg);
-        lastMessageRxTime = millis();
-        // We only care about the ping if we haven't heard recently
-        // Clear flag when we get any traffic
-        timeoutPingSent = false;
-        curMsg = String();
-    }
-
-    if(lastMessageRxTime > 0) 
-    {
-        unsigned long diff = millis() - lastMessageRxTime;
-        //We first check if it's been too long and we need to time out
-        if(diff > TIMEOUT_AFTER_IDLE_INTERVAL) 
-        {
-            connectedToEos = false;
-            lastMessageRxTime = 0;
-            updateDisplay = true;
-            timeoutPingSent = false;
-        }
-
-        //It could be the console is sitting idle. Send a ping once to
-        // double check that it's still there, but only once after 2.5s have passed
-        if(!timeoutPingSent && diff > PING_AFTER_IDLE_INTERVAL) 
-        {
-              OSCMessage ping("/eos/ping");
-              ping.add("box1_hello"); // This way we know who is sending the ping
-              SLIPSerial.beginPacket();
-              ping.send(SLIPSerial);
-              SLIPSerial.endPacket();
-              timeoutPingSent = true;
-        }
+      connectedToConsole = ConsoleNone;
+      lastMessageRxTime = 0;
+      updateDisplay = true;
+      timeoutPingSent = false;
     }
 
-    if (updateDisplay)
-        displayStatus();
+    //It could be the console is sitting idle. Send a ping once to
+    // double check that it's still there, but only once after 2.5s have passed
+    if (!timeoutPingSent && diff > PING_AFTER_IDLE_INTERVAL)
+    {
+      OSCMessage ping("/eos/ping");
+      ping.add(BOX_NAME_STRING "_hello"); // This way we know who is sending the ping
+      SLIPSerial.beginPacket();
+      ping.send(SLIPSerial);
+      SLIPSerial.endPacket();
+      timeoutPingSent = true;
+    }
+  }
+
+  if (updateDisplay)
+    displayStatus();
 }
-


### PR DESCRIPTION
Each ETC console uses a different OSC command set.

This change adds automatic console-type detection when receiving OSC, allowing a a single firmware image to support multiple OSC-over-USB consoles without recompiling.